### PR TITLE
fix: remove comparing state hash for the genesis block

### DIFF
--- a/genesis/genesis.go
+++ b/genesis/genesis.go
@@ -2,7 +2,6 @@ package genesis
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"time"
 
@@ -66,7 +65,7 @@ type genesisData struct {
 func (gen *Genesis) Hash() hash.Hash {
 	bs, err := cbor.Marshal(gen.data)
 	if err != nil {
-		panic(fmt.Errorf("could not create hash of Genesis: %w", err))
+		return hash.UndefHash
 	}
 
 	return hash.CalcHash(bs)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -561,29 +561,6 @@ func TestLoadState(t *testing.T) {
 	require.NoError(t, newState.CommitBlock(blk6, cert6))
 }
 
-func TestLoadStateAfterChangingGenesis(t *testing.T) {
-	td := setup(t)
-
-	_, err := LoadOrNewState(td.state.genDoc, td.state.valKeys,
-		td.state.store, txpool.MockingTxPool(), nil)
-	require.NoError(t, err)
-
-	pub, _ := td.RandBLSKeyPair()
-	val := validator.NewValidator(pub, 4)
-	newVals := append(td.state.genDoc.Validators(), val)
-
-	genDoc := genesis.MakeGenesis(
-		td.state.genDoc.GenesisTime(),
-		td.state.genDoc.Accounts(),
-		newVals,
-		td.state.genDoc.Params())
-
-	// Load last state info after modifying genesis
-	_, err = LoadOrNewState(genDoc, td.state.valKeys,
-		td.state.store, txpool.MockingTxPool(), nil)
-	require.Error(t, err)
-}
-
 func TestIsValidator(t *testing.T) {
 	td := setup(t)
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -643,9 +643,6 @@ func TestCommittedBlock(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, blockOne.PrevCertificate())
 		assert.Equal(t, hash.UndefHash, blockOne.Header().PrevBlockHash())
-
-		r := td.state.calculateGenesisStateRootFromGenesisDoc()
-		assert.Equal(t, blockOne.Header().StateRoot(), r)
 	})
 
 	t.Run("Last block", func(t *testing.T) {

--- a/store/block.go
+++ b/store/block.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pactus-project/pactus/types/block"
 	"github.com/pactus-project/pactus/util"
 	"github.com/pactus-project/pactus/util/encoding"
-	"github.com/pactus-project/pactus/util/logger"
 	"github.com/pactus-project/pactus/util/pairslice"
 	"github.com/syndtr/goleveldb/leveldb"
 )
@@ -47,15 +46,6 @@ func newBlockStore(db *leveldb.DB, sortitionCacheSize uint32, publicKeyCacheSize
 }
 
 func (bs *blockStore) saveBlock(batch *leveldb.Batch, height uint32, blk *block.Block) []blockRegion {
-	if height > 1 {
-		if !bs.hasBlock(height - 1) {
-			logger.Panic("previous block not found", "height", height)
-		}
-	}
-	if bs.hasBlock(height) {
-		logger.Panic("duplicated block", "height", height)
-	}
-
 	blockHash := blk.Hash()
 	regs := make([]blockRegion, blk.Transactions().Len())
 	w := bytes.NewBuffer(make([]byte, 0, blk.SerializeSize()+hash.HashSize))

--- a/store/block_test.go
+++ b/store/block_test.go
@@ -13,16 +13,6 @@ func TestBlockStore(t *testing.T) {
 	lastCert := td.store.LastCertificate()
 	lastHeight := lastCert.Height()
 	nextBlk, nextCert := td.GenerateTestBlock(lastHeight + 1)
-	nextNextBlk, nextNextCert := td.GenerateTestBlock(lastHeight + 2)
-
-	t.Run("Missed block, Should panic ", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("The code did not panic")
-			}
-		}()
-		td.store.SaveBlock(nextNextBlk, nextNextCert)
-	})
 
 	t.Run("Add block, don't batch write", func(t *testing.T) {
 		td.store.SaveBlock(nextBlk, nextCert)
@@ -45,15 +35,6 @@ func TestBlockStore(t *testing.T) {
 		cert := td.store.LastCertificate()
 		assert.NoError(t, err)
 		assert.Equal(t, cert.Hash(), nextCert.Hash())
-	})
-
-	t.Run("Duplicated block, Should panic ", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("The code did not panic")
-			}
-		}()
-		td.store.SaveBlock(nextBlk, nextCert)
 	})
 }
 

--- a/store/config.go
+++ b/store/config.go
@@ -9,7 +9,7 @@ import (
 
 type Config struct {
 	Path          string `toml:"path"`
-	RetentionDays uint   `toml:"retention_days"`
+	RetentionDays uint32 `toml:"retention_days"`
 
 	// Private configs
 	TxCacheSize        uint32                  `toml:"-"`
@@ -66,5 +66,5 @@ func (conf *Config) BasicCheck() error {
 }
 
 func (conf *Config) RetentionBlocks() uint32 {
-	return uint32(conf.RetentionDays * 8640)
+	return conf.RetentionDays * 8640
 }

--- a/types/block/block.go
+++ b/types/block/block.go
@@ -134,6 +134,14 @@ func (b *Block) Hash() hash.Hash {
 	return h
 }
 
+func (b *Block) Height() uint32 {
+	if b.data.PrevCert == nil {
+		return 1
+	}
+
+	return b.PrevCertificate().Height() + 1
+}
+
 func (b *Block) String() string {
 	return fmt.Sprintf("{⌘ %v 👤 %v 💻 %v 📨 %d}",
 		b.Hash().ShortString(),

--- a/types/block/block_test.go
+++ b/types/block/block_test.go
@@ -341,3 +341,16 @@ func TestMakeBlock(t *testing.T) {
 
 	assert.Equal(t, blk0.Hash(), blk1.Hash())
 }
+
+func TestBlockHeight(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+
+	blk1, _ := ts.GenerateTestBlock(1, testsuite.BlockWithPrevCert(nil), testsuite.BlockWithPrevHash(hash.UndefHash))
+	blk2, _ := ts.GenerateTestBlock(2)
+
+	assert.NoError(t, blk1.BasicCheck())
+	assert.NoError(t, blk2.BasicCheck())
+
+	assert.Equal(t, uint32(1), blk1.Height())
+	assert.Equal(t, uint32(2), blk2.Height())
+}


### PR DESCRIPTION
## Description

This PR remove comparison of state hash for the genesis block and update the prune code on committing new block.